### PR TITLE
Affine transform with tensors to preserve grad_fn

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,15 +107,16 @@ def train(args,train,test,device):
             if (batch_idx+1) % 50 == 0 or (batch_idx+1) == len(train):
                 logging.info('==>>> epoch: {}, batch index: {}, train loss: {:.6f}'.format(
                     epoch, batch_idx+1, ave_loss))
-            if (epoch+1)%50 == 0:
-                scae.eval()
-                accuracy = evaluate(scae,train=train,test=test,K=K,device=device)
-                if accuracy>prev_best_accuracy:
-                    prev_best_accuracy = accuracy
-                    torch.save(scae, model_name)
-                    logging.debug("saving model"+str(model_name)+" "+"with test_accuracy:"+ str(accuracy))
-                logging.debug('epoch ' + str(epoch) + 'test-accuracy: '
-                            + str(accuracy))
+
+        if (epoch+1)%50 == 0:
+            scae.eval()
+            accuracy = evaluate(scae,train=train,test=test,K=K,device=device)
+            if accuracy>prev_best_accuracy:
+                prev_best_accuracy = accuracy
+                torch.save(scae, model_name)
+                logging.debug("saving model"+str(model_name)+" "+"with test_accuracy:"+ str(accuracy))
+            logging.debug('epoch ' + str(epoch) + 'test-accuracy: '
+                        + str(accuracy))
     return
 
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ import model
 
 np.set_printoptions(precision=4, suppress=True)
 
+
 def seed_everything(seed=1234):
     random.seed(seed)
     os.environ['PYTHONHASHSEED'] = str(seed)
@@ -29,6 +30,7 @@ def seed_everything(seed=1234):
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     torch.backends.cudnn.deterministic = True
+
 
 def evaluate(model,train,test,K,device):
     model.eval()
@@ -44,8 +46,7 @@ def evaluate(model,train,test,K,device):
             if (max_act>prev_max).sum()!=0:
                 prev_labels[max_act>prev_max]= target[max_ex]
                 prev_max[max_act>prev_max]= max_act[max_act>prev_max]
-        
-    
+
     count = 0 
     total_count = 0
     with torch.no_grad():
@@ -152,6 +153,7 @@ def main():
                     dataset=test_set,
                     batch_size=args.batch_size,
                     shuffle=False)
+
     if args.mode == 'train':
         train(args,train=train_loader,test=test_loader,device=device)
     else:
@@ -163,5 +165,5 @@ def main():
         print("accuracy: %0.4f"%accuracy)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()

--- a/model.py
+++ b/model.py
@@ -51,18 +51,15 @@ class PCAE(nn.Module):
             noise_1 = torch.zeros(*part_capsule_param.size()[:2]).to(device)
         x_m,d_m,c_z = self.relu(part_capsule_param[:,:,:6]),self.sigmoid(part_capsule_param[:,:,6]+noise_1).view(*part_capsule_param.size()[:2],1),self.relu(part_capsule_param[:,:,7:])
 
-        # pytorch doesn't  support batch transforms 
-        temp=[]
-        for pose in x_m:
-            temp2=[]
-            for pos,template in enumerate(self.templates):
-                temp2.append(self.to_tensor(F1.resize(F1.affine(self.to_pil(template),
-                                                        pose[pos][0],
-                                                        (pose[pos][1],pose[pos][2]),
-                                                        pose[pos][3]+self.epsilon, # for accounting zero scale values
-                                                        (pose[pos][4],pose[pos][5])),x.size()[2:])))
-            temp.append(torch.cat(temp2,0).unsqueeze(0)) #(1,M,28,28)
-        transformed_templates = torch.cat(temp,0).to(device) #(B,M,28,28)
+        # Affine Transform
+        B, _, _, target_size = x.size()
+        transformed_templates = [F.grid_sample(self.templates[i].repeat(B,1,1,1).to(device), # sce.to(device) could not transfrom self.templates to "cuda"
+                                               F.affine_grid(
+                                                   self.geometric_transform(x_m[:,i,:]),  # pose
+                                                   torch.Size((B, 1, target_size, target_size)) # size
+                                               ))
+                                 for i in range(self.num_capsules)]
+        transformed_templates = torch.cat(transformed_templates, 1).to(device)
         mix_prob = self.soft_max(d_m*transformed_templates.view(*transformed_templates.size()[:2],-1)).view_as(transformed_templates)
         detach_x = x.data
         std= detach_x.view(*x.size()[:2],-1).std(-1).unsqueeze(1)  #(B,1,1)
@@ -82,6 +79,50 @@ class PCAE(nn.Module):
         
         return log_likelihood,input_ocae,x_m_detach,d_m_detach
 
+    @staticmethod
+    def geometric_transform(pose_tensor, similarity=False, nonlinear=True):
+        """Convers paramer tensor into an affine or similarity transform.
+        This function is adapted from:
+        https://github.com/akosiorek/stacked_capsule_autoencoders/blob/master/capsules/math_ops.py
+
+        Args:
+        pose_tensor: [..., 6] tensor.
+        similarity: bool.
+        nonlinear: bool; applies nonlinearities to pose params if True.
+
+        Returns:
+        [..., 2, 3] tensor.
+        """
+
+        scale_x, scale_y, theta, shear, trans_x, trans_y = torch.split(pose_tensor, 1, -1)
+
+        if nonlinear:
+            scale_x, scale_y = torch.sigmoid(scale_x) + 1e-2, torch.sigmoid(scale_y) + 1e-2
+            trans_x, trans_y, shear = torch.tanh(trans_x * 5.),  torch.tanh(trans_y * 5.), torch.tanh(shear * 5.)
+            theta *= 2. * math.pi
+        else:
+            scale_x, scale_y = (abs(i) + 1e-2 for i in (scale_x, scale_y))
+
+        c, s = torch.cos(theta), torch.sin(theta)
+
+        if similarity:
+            scale = scale_x
+            pose = [scale * c, -scale * s, trans_x, scale * s, scale * c, trans_y]
+
+        else:
+            pose = [
+                scale_x * c + shear * scale_y * s, -scale_x * s + shear * scale_y * c,
+                trans_x, scale_y * s, scale_y * c, trans_y
+            ]
+
+        pose = torch.cat(pose, -1)
+
+        # convert to a matrix
+        shape = list(pose.shape[:-1])
+        shape += [2, 3]
+        pose = torch.reshape(pose, shape)
+
+        return pose
 
 class SetTransformer(nn.Module):
     def __init__(self, dim_input, num_outputs, dim_output,

--- a/model.py
+++ b/model.py
@@ -59,7 +59,7 @@ class PCAE(nn.Module):
                                                    torch.Size((B, 1, target_size, target_size)) # size
                                                ))
                                  for i in range(self.num_capsules)]
-        transformed_templates = torch.cat(transformed_templates, 1).to(device)
+        transformed_templates = torch.cat(transformed_templates, 1)
         mix_prob = self.soft_max(d_m*transformed_templates.view(*transformed_templates.size()[:2],-1)).view_as(transformed_templates)
         detach_x = x.data
         std= detach_x.view(*x.size()[:2],-1).std(-1).unsqueeze(1)  #(B,1,1)


### PR DESCRIPTION
In summary, this version performs the affine transform of templets with the pytorch tensors, so that the **grad_fn** of _x_m_ and _templets_ could be preserved. Moreover, combined with list parsing, the changes boost the computing efficiency.